### PR TITLE
Allow test writer to specify which event loop to use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,42 @@ You can specify how many seconds to wait *after* running the callback tests by s
 		  return callback_test
 		  
 
+Supplying your own event loop
+-----------------------------------
+
+By default, aio.testing creates a new event loop for each test. There may be
+times that you prefer to control which event loop the tests are executed on.
+For example, you may create some expensive resource on a loop in a fixture
+that you wish to share among tests.
+
+Both aio.testing.run_until_complete and aio.testing.run_forever accept an
+optional named argument called :code:`loop`. The value of :code:`loop` should
+be a `context manager`_ that returns a loop. aio.testing provides the
+:code:`current_loop` context manager which simply returns the value of
+asyncio.get_event_loop():
+
+.. _context manager: https://docs.python.org/3/reference/datamodel.html#context-managers
+
+.. code:: python
+
+	  import unittest
+	  import asyncio
+
+	  import aio.testing
+
+
+	  class MyTestCase(unittest.TestCase):
+
+              @classmethod
+              def setUpClass(cls):
+                  cls.loop = asyncio.get_event_loop()
+
+	      @aio.testing.run_until_complete(loop=aio.testing.current_loop)
+	      def test_example():
+	          yield from asyncio.sleep(2)
+		  self.assertEqual(asyncio.get_event_loop(), MyTestCase.loop)
+
+
 Contributing
 -----------------------------------
 
@@ -169,4 +205,10 @@ To run unit tests, use:
 .. code:: bash
 
 	  python setup.py test
+
+To run doc tests, use:
+
+.. code:: bash
+
+	  python -m doctest aio/testing/README.rst
 

--- a/aio/testing/tests/test_contextmanagers.py
+++ b/aio/testing/tests/test_contextmanagers.py
@@ -1,7 +1,7 @@
 import io
 import unittest
 
-import sys
+import asyncio
 import os
 
 
@@ -12,24 +12,56 @@ ROOT_PATH = os.path.abspath(
 #assert False, sys.path
 
 from aio.testing.contextmanagers import redirect_stderr, redirect_all
-from aio.testing import run_until_complete, run_forever
+from aio.testing import run_until_complete, run_forever, current_loop
+
 
 class AioTestingContextmanagersTestCase(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.parent_loop = asyncio.get_event_loop()
+
     @run_until_complete
     def test_run_until_complete(self):
-        self.assertEqual(self.test_run_until_complete.__name__, 
-            'test_run_until_complete')
+        self.assertEqual(self.test_run_until_complete.__name__,
+                         'test_run_until_complete')
+        self.assertNotEqual(asyncio.get_event_loop(),
+                            AioTestingContextmanagersTestCase.parent_loop)
+
+    @run_until_complete(loop=current_loop)
+    def test_run_until_complete_current_loop(self):
+        self.assertEqual(self.test_run_until_complete_current_loop.__name__,
+                         'test_run_until_complete_current_loop')
+        self.assertEqual(asyncio.get_event_loop(),
+                         AioTestingContextmanagersTestCase.parent_loop)
 
     @run_forever
     def test_run_forever(self):
-        self.assertEqual(self.test_run_forever.__name__, 
-            'test_run_forever')
+        self.assertEqual(self.test_run_forever.__name__,
+                         'test_run_forever')
+        self.assertNotEqual(asyncio.get_event_loop(),
+                            AioTestingContextmanagersTestCase.parent_loop)
+
+    @run_forever(loop=current_loop)
+    def test_run_forever_current_loop(self):
+        self.assertEqual(self.test_run_forever.__name__,
+                         'test_run_forever')
+        self.assertEqual(asyncio.get_event_loop(),
+                         AioTestingContextmanagersTestCase.parent_loop)
 
     @run_forever(timeout=1)
     def test_run_forever_with_args(self):
-        self.assertEqual(self.test_run_forever.__name__, 
+        self.assertEqual(self.test_run_forever.__name__,
             'test_run_forever')
+        self.assertNotEqual(asyncio.get_event_loop(),
+                            AioTestingContextmanagersTestCase.parent_loop)
+
+    @run_forever(timeout=1, loop=current_loop)
+    def test_run_forever_with_args_current_loop(self):
+        self.assertEqual(self.test_run_forever.__name__,
+                         'test_run_forever')
+        self.assertEqual(asyncio.get_event_loop(),
+                         AioTestingContextmanagersTestCase.parent_loop)
 
     def test_redirect_stderr(self):
         with io.StringIO() as o, redirect_stderr(o):


### PR DESCRIPTION
Closes #3. Keeps default behavior, but allows the test writer to reuse the original event loop.